### PR TITLE
Remove parameter pollution in function to_zero

### DIFF
--- a/wellpathpy/location.py
+++ b/wellpathpy/location.py
@@ -68,8 +68,8 @@ def to_zero(tvd, northing, easting, surface_northing, surface_easting):
 
     tvd, northing, easting = checkarrays_tvd(tvd, northing, easting)
 
-    northing -= surface_northing
-    easting -= surface_easting
+    northing = northing - surface_northing
+    easting = easting - surface_easting
 
     return tvd, northing, easting
 


### PR DESCRIPTION
This PR aims to improve the function `to_zero` by removing the side effect of parameter pollution. The test `test_zero` can fail if run twice by running `pip3 install pytest-repeat; python3 -m pytest --count=2 wellpathpy/test/test_location.py::test_zero`
```
    def test_zero():
        # test well9
        _, well9_northing, well9_easting, _ = minimum_curvature(well9_true_md_m, well9_true_inc, well9_true_azi)
        tvd, mN, mE = to_zero(
            well9_true_tvd_m,
            well9_true_northing,
            well9_true_easting,
            well9_true_surface_northing,
            well9_true_surface_easting
            )
        np.testing.assert_equal(tvd, well9_true_tvd_m)
>       np.testing.assert_allclose(mN, well9_northing, atol=1)
E       AssertionError:
E       Not equal to tolerance rtol=1e-07, atol=1
E
E       Mismatched elements: 121 / 121 (100%)
E       Max absolute difference: 39998.454
E       Max relative difference: 13192276.67957119
```
After careful inspection, I find that the reason why it fails on the second run is because the parameter passed into the function `to_zero` is modified after the invocation.

The fix is to make the function `to_zero` not change the arguments passed in any more. It may be worth noting that for numpy arrays passed (as references) into the function, code like `x-=y` directly modifies the numpy array `x` itself, while `x = x - y` can avoid polluting the arguments. You may want to refer to https://stackoverflow.com/questions/11585793/are-numpy-arrays-passed-by-reference for more details.

It may be better to avoid such pollutions so that some other tests won't fail in the future due to the pollution.